### PR TITLE
Split fix

### DIFF
--- a/source/DBUtility.py
+++ b/source/DBUtility.py
@@ -141,7 +141,7 @@ def get_latest_dbinstance(query, database):
     return None, None, None
 
 def execute_generic_command(command):
-    # split the command, but keep items in parenthesis together
+    # split the command, but keep items in quotes together
     command_tokens = shlex.split(command)
     result = subprocess.run(command_tokens, stdout=subprocess.PIPE)
     print(result.stdout.decode('utf-8'))

--- a/source/DBUtility.py
+++ b/source/DBUtility.py
@@ -1,3 +1,4 @@
+import shlex
 import subprocess
 import pickle
 import sqlite3
@@ -140,7 +141,8 @@ def get_latest_dbinstance(query, database):
     return None, None, None
 
 def execute_generic_command(command):
-    command_tokens = command.split()
+    # split the command, but keep items in parenthesis together
+    command_tokens = shlex.split(command)
     result = subprocess.run(command_tokens, stdout=subprocess.PIPE)
     print(result.stdout.decode('utf-8'))
     return result.stdout.decode('utf-8')


### PR DESCRIPTION
When using the blastdb_aliastool tool, `execute_generic_command` does not correctly split `-dblist` when there is more than one argument.

This leads to errors like: "Error: Too many positional arguments."

This fix utilizes a standard library split function that will keep items inside of quotes together when splitting.